### PR TITLE
feature: support claude code arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,42 @@ If a model is configured in the profile, the `--model` parameter is automaticall
 claude --model glm-4-plus [other arguments...]
 ```
 
+## Argument Separation with `--`
+
+The tool supports the `--` separator to clearly distinguish between arguments for `ai-claude-start` and arguments for the Claude CLI:
+
+### Syntax
+```bash
+ai-claude-start [ai-claude-start-args] -- [claude-code-args]
+```
+
+- Everything before `--` is processed by `ai-claude-start` (profile name, options, etc.)
+- Everything after `--` is passed directly to the Claude CLI
+
+### Examples
+
+**Using Claude-specific flags**:
+```bash
+# Use default profile with Claude Code flags
+ai-claude-start -- --dangerously-skip-permissions
+
+ai-claude-start -- --continue
+
+# Use specific profile with Claude Code flags
+ai-claude-start my-profile -- --dangerously-skip-permissions
+
+ai-claude-start my-profile -- --continue
+```
+
+**When to use `--`**:
+- When you need to pass flags that might conflict with `ai-claude-start` options
+- When you want clearer separation of concerns
+- When using complex command structures with multiple flags
+
+**When `--` is optional**:
+- For simple cases like `ai-claude-start my-profile --version`, the separator is not needed
+- The tool intelligently parses profile names vs. Claude arguments
+
 ## Testing Without Claude CLI
 
 For testing or development without the actual Claude CLI installed:

--- a/README_CN.md
+++ b/README_CN.md
@@ -166,6 +166,43 @@ ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic
 claude --model glm-4-plus [其他参数...]
 ```
 
+## 使用 `--` 分离参数
+
+工具支持 `--` 分隔符来清晰区分 `ai-claude-start` 的参数和 Claude Code 的参数：
+
+### 语法
+```bash
+ai-claude-start [ai-claude-start-参数] -- [claude-code-参数]
+```
+
+- `--` 之前的所有内容由 `ai-claude-start` 处理（配置名、选项等）
+- `--` 之后的所有内容直接传递给 Claude Code
+
+### 示例
+
+**使用 Claude 特定的标志**：
+```bash
+# 使用默认配置和 Claude Code 参数
+ai-claude-start -- --dangerously-skip-permissions
+
+ai-claude-start -- --continue
+
+# 使用指定配置和 Claude Code 参数
+ai-claude-start my-profile -- --dangerously-skip-permissions
+
+ai-claude-start my-profile -- --continue
+
+```
+
+**何时使用 `--`**：
+- 需要传递可能与 `ai-claude-start` 选项冲突的标志时
+- 希望更清晰地区分不同用途的参数时
+- 使用复杂的命令结构和多个标志时
+
+**何时 `--` 是可选的**：
+- 对于简单情况如 `ai-claude-start my-profile --version`，不需要分隔符
+- 工具会智能解析配置名与 Claude 参数
+
 ## 无需 Claude CLI 测试
 
 用于测试或开发，无需安装实际的 Claude CLI：

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,7 @@ program
 
 // Handle direct execution: claude-start [profile] [args...]
 // or: claude-start [args...] (uses default profile)
+// or: claude-start [ai-claude-args] -- [claude-args]
 program.action(async (options, cmd) => {
   const args = process.argv.slice(2);
 
@@ -78,19 +79,39 @@ program.action(async (options, cmd) => {
     return;
   }
 
-  // Check if first arg is a profile name
-  const config = readConfig();
-  const firstArgIsProfile = args.length > 0 && config.profiles.some((p) => p.name === args[0]);
+  // Support -- separator like dlv: everything before -- is for ai-claude-start,
+  // everything after -- is passed directly to claude
+  const doubleDashIndex = args.indexOf('--');
 
   let profileName: string | undefined;
   let claudeArgs: string[];
 
-  if (firstArgIsProfile) {
-    profileName = args[0];
-    claudeArgs = args.slice(1);
+  if (doubleDashIndex >= 0) {
+    // Using -- separator
+    const aiArgs = args.slice(0, doubleDashIndex);
+    claudeArgs = args.slice(doubleDashIndex + 1);
+
+    // Check if first arg in ai-claude-start section is a profile name
+    const config = readConfig();
+    const firstArgIsProfile = aiArgs.length > 0 && config.profiles.some((p) => p.name === aiArgs[0]);
+
+    if (firstArgIsProfile) {
+      profileName = aiArgs[0];
+    } else {
+      profileName = undefined; // Use default
+    }
   } else {
-    profileName = undefined; // Use default
-    claudeArgs = args;
+    // No -- separator, use original logic
+    const config = readConfig();
+    const firstArgIsProfile = args.length > 0 && config.profiles.some((p) => p.name === args[0]);
+
+    if (firstArgIsProfile) {
+      profileName = args[0];
+      claudeArgs = args.slice(1);
+    } else {
+      profileName = undefined; // Use default
+      claudeArgs = args;
+    }
   }
 
   await executeWithProfile(profileName, claudeArgs);

--- a/src/executor.test.ts
+++ b/src/executor.test.ts
@@ -1,98 +1,76 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { sanitizeEnvironment, prepareEnvironment } from './executor.js';
+import { describe, it, expect } from 'vitest';
+import { buildSettingsArg } from './executor.js';
 import type { Profile } from './types.js';
 
 describe('executor', () => {
-  describe('sanitizeEnvironment', () => {
-    beforeEach(() => {
-      // Reset environment
-      vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
-      vi.stubEnv('ANTHROPIC_AUTH_TOKEN', 'test-token');
-      vi.stubEnv('ANTHROPIC_BASE_URL', 'https://test.com');
-      vi.stubEnv('OTHER_VAR', 'keep-this');
-      vi.stubEnv('PATH', '/usr/bin');
-    });
-
-    it('should remove all ANTHROPIC_* environment variables', () => {
-      const clean = sanitizeEnvironment();
-
-      expect(clean).not.toHaveProperty('ANTHROPIC_API_KEY');
-      expect(clean).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN');
-      expect(clean).not.toHaveProperty('ANTHROPIC_BASE_URL');
-      expect(clean).toHaveProperty('OTHER_VAR', 'keep-this');
-      expect(clean).toHaveProperty('PATH', '/usr/bin');
-    });
-
-    it('should preserve non-ANTHROPIC variables', () => {
-      const clean = sanitizeEnvironment();
-
-      expect(clean.OTHER_VAR).toBe('keep-this');
-      expect(clean.PATH).toBe('/usr/bin');
-    });
-  });
-
-  describe('prepareEnvironment', () => {
+  describe('buildSettingsArg', () => {
     const mockProfile: Profile = {
       name: 'test',
       baseUrl: 'https://api.example.com',
       model: 'test-model'
     };
 
-    beforeEach(() => {
-      vi.stubEnv('ANTHROPIC_API_KEY', 'old-key');
-      vi.stubEnv('ANTHROPIC_AUTH_TOKEN', 'old-token');
-      vi.stubEnv('OTHER_VAR', 'keep-this');
+    it('should build settings with ANTHROPIC_AUTH_TOKEN', () => {
+      const settings = buildSettingsArg(mockProfile, 'my-secret-token');
+      const parsed = JSON.parse(settings);
+
+      expect(parsed).toHaveProperty('env');
+      expect(parsed.env).toHaveProperty('ANTHROPIC_AUTH_TOKEN', 'my-secret-token');
+      expect(parsed.env).toHaveProperty('ANTHROPIC_BASE_URL', 'https://api.example.com');
     });
 
-    it('should always use ANTHROPIC_AUTH_TOKEN for credentials', async () => {
-      const env = await prepareEnvironment(mockProfile, 'my-secret-token');
+    it('should set ANTHROPIC_BASE_URL for non-default base URLs', () => {
+      const settings = buildSettingsArg(mockProfile, 'test-token');
+      const parsed = JSON.parse(settings);
 
-      expect(env).not.toHaveProperty('ANTHROPIC_API_KEY');
-      expect(env).toHaveProperty('ANTHROPIC_AUTH_TOKEN', 'my-secret-token');
-      expect(env).toHaveProperty('OTHER_VAR', 'keep-this');
+      expect(parsed.env).toHaveProperty('ANTHROPIC_BASE_URL', 'https://api.example.com');
+      expect(parsed.env).toHaveProperty('ANTHROPIC_AUTH_TOKEN', 'test-token');
     });
 
-    it('should set ANTHROPIC_BASE_URL for non-default base URLs', async () => {
-      const env = await prepareEnvironment(mockProfile, 'test-token');
-
-      expect(env).toHaveProperty('ANTHROPIC_BASE_URL', 'https://api.example.com');
-      expect(env).toHaveProperty('ANTHROPIC_AUTH_TOKEN', 'test-token');
-    });
-
-    it('should not set ANTHROPIC_BASE_URL for default Anthropic URL', async () => {
+    it('should not set ANTHROPIC_BASE_URL for default Anthropic URL', () => {
       const anthropicProfile: Profile = {
         name: 'anthropic',
         baseUrl: 'https://api.anthropic.com'
       };
 
-      const env = await prepareEnvironment(anthropicProfile, 'test-token');
+      const settings = buildSettingsArg(anthropicProfile, 'test-token');
+      const parsed = JSON.parse(settings);
 
-      expect(env).not.toHaveProperty('ANTHROPIC_BASE_URL');
-      expect(env).toHaveProperty('ANTHROPIC_AUTH_TOKEN', 'test-token');
+      expect(parsed.env).not.toHaveProperty('ANTHROPIC_BASE_URL');
+      expect(parsed.env).toHaveProperty('ANTHROPIC_AUTH_TOKEN', 'test-token');
     });
 
-    it('should handle Moonshot profile correctly', async () => {
+    it('should handle Moonshot profile correctly', () => {
       const moonshotProfile: Profile = {
         name: 'moonshot',
         baseUrl: 'https://api.moonshot.cn/anthropic'
       };
 
-      const env = await prepareEnvironment(moonshotProfile, 'moonshot-token-123');
+      const settings = buildSettingsArg(moonshotProfile, 'moonshot-token-123');
+      const parsed = JSON.parse(settings);
 
-      expect(env).toHaveProperty('ANTHROPIC_AUTH_TOKEN', 'moonshot-token-123');
-      expect(env).toHaveProperty('ANTHROPIC_BASE_URL', 'https://api.moonshot.cn/anthropic');
+      expect(parsed.env).toHaveProperty('ANTHROPIC_AUTH_TOKEN', 'moonshot-token-123');
+      expect(parsed.env).toHaveProperty('ANTHROPIC_BASE_URL', 'https://api.moonshot.cn/anthropic');
     });
 
-    it('should handle BigModel profile correctly', async () => {
+    it('should handle BigModel profile correctly', () => {
       const bigmodelProfile: Profile = {
         name: 'bigmodel',
         baseUrl: 'https://open.bigmodel.cn/api/anthropic'
       };
 
-      const env = await prepareEnvironment(bigmodelProfile, 'bigmodel-token-456');
+      const settings = buildSettingsArg(bigmodelProfile, 'bigmodel-token-456');
+      const parsed = JSON.parse(settings);
 
-      expect(env).toHaveProperty('ANTHROPIC_AUTH_TOKEN', 'bigmodel-token-456');
-      expect(env).toHaveProperty('ANTHROPIC_BASE_URL', 'https://open.bigmodel.cn/api/anthropic');
+      expect(parsed.env).toHaveProperty('ANTHROPIC_AUTH_TOKEN', 'bigmodel-token-456');
+      expect(parsed.env).toHaveProperty('ANTHROPIC_BASE_URL', 'https://open.bigmodel.cn/api/anthropic');
+    });
+
+    it('should return valid JSON string', () => {
+      const settings = buildSettingsArg(mockProfile, 'test-token');
+
+      // Should not throw
+      expect(() => JSON.parse(settings)).not.toThrow();
     });
   });
 });

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -5,39 +5,26 @@ import { readConfig, getCredential } from './storage.js';
 import type { Profile } from './types.js';
 
 /**
- * Sanitize environment variables - remove all ANTHROPIC_* vars
+ * Build --settings argument for claude CLI
+ * Uses --settings to set env vars with higher priority than environment variables
+ * This allows overriding settings.json in code repositories
  */
-export function sanitizeEnvironment(): Record<string, string> {
-  const clean: Record<string, string> = {};
-
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined && !key.startsWith('ANTHROPIC_')) {
-      clean[key] = value;
-    }
-  }
-
-  return clean;
-}
-
-/**
- * Prepare environment for a profile
- * Always use ANTHROPIC_AUTH_TOKEN for credentials
- */
-export async function prepareEnvironment(
+export function buildSettingsArg(
   profile: Profile,
   credential: string
-): Promise<Record<string, string>> {
-  const env = sanitizeEnvironment();
-
-  // Always use ANTHROPIC_AUTH_TOKEN
-  env['ANTHROPIC_AUTH_TOKEN'] = credential;
+): string {
+  const settings: { env: Record<string, string> } = {
+    env: {
+      ANTHROPIC_AUTH_TOKEN: credential
+    }
+  };
 
   // Set base URL if not default Anthropic
   if (profile.baseUrl !== 'https://api.anthropic.com') {
-    env['ANTHROPIC_BASE_URL'] = profile.baseUrl;
+    settings.env.ANTHROPIC_BASE_URL = profile.baseUrl;
   }
 
-  return env;
+  return JSON.stringify(settings);
 }
 
 /**
@@ -107,8 +94,10 @@ export async function executeWithProfile(
     process.exit(1);
   }
 
-  // Prepare environment
-  const env = await prepareEnvironment(targetProfile, credential);
+  // Build --settings argument with higher priority than environment variables
+  const settingsJson = buildSettingsArg(targetProfile, credential);
+  // Wrap JSON in single quotes for shell compatibility
+  const settingsArg = `'${settingsJson}'`;
 
   // Determine command to run
   const cmdBinary = process.env.CLAUDE_CMD || args.find((arg) => arg === '--cmd')
@@ -122,6 +111,9 @@ export async function executeWithProfile(
     claudeArgs = [...args.slice(0, cmdIndex), ...args.slice(cmdIndex + 2)];
   }
 
+  // Add --settings parameter at the beginning (before other args for proper parsing)
+  claudeArgs = ['--settings', settingsArg, ...claudeArgs];
+
   // Add --model parameter if profile has model configured and not already specified
   if (targetProfile.model && !claudeArgs.includes('--model')) {
     claudeArgs = ['--model', targetProfile.model, ...claudeArgs];
@@ -134,9 +126,8 @@ export async function executeWithProfile(
     console.log(chalk.blue(`   Model: ${targetProfile.model}`));
   }
 
-  // Execute
+  // Execute - use process.env directly (settings will override env vars via --settings)
   const child = spawn(cmdBinary, claudeArgs, {
-    env,
     stdio: 'inherit',
     shell: true
   });


### PR DESCRIPTION
支持启动时携带claude code的相关参数: #1 

```shell
# 使用默认配置和 Claude Code 参数
ai-claude-start -- --dangerously-skip-permissions

ai-claude-start -- --continue

# 使用指定配置和 Claude Code 参数
ai-claude-start my-profile -- --dangerously-skip-permissions

ai-claude-start my-profile -- --continue
```